### PR TITLE
Web Front 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>annotationProcessor</scope>

--- a/src/main/java/com/nhnacademy/gateway/GatewayServiceApplication.java
+++ b/src/main/java/com/nhnacademy/gateway/GatewayServiceApplication.java
@@ -3,7 +3,9 @@ package com.nhnacademy.gateway;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @EnableDiscoveryClient
 @SpringBootApplication
 public class GatewayServiceApplication {

--- a/src/main/java/com/nhnacademy/gateway/broker/BrokerType.java
+++ b/src/main/java/com/nhnacademy/gateway/broker/BrokerType.java
@@ -1,6 +1,8 @@
-package com.nhnacademy.gateway.broker.mqtt.dto;
+package com.nhnacademy.gateway.broker;
 
 public enum BrokerType {
+
     CORE,
+
     INBOUND
 }

--- a/src/main/java/com/nhnacademy/gateway/common/annotation/CheckRole.java
+++ b/src/main/java/com/nhnacademy/gateway/common/annotation/CheckRole.java
@@ -1,0 +1,15 @@
+package com.nhnacademy.gateway.common.annotation;
+
+import com.nhnacademy.gateway.common.enums.RoleType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckRole {
+
+    RoleType value();
+}

--- a/src/main/java/com/nhnacademy/gateway/common/aspect/RoleCheckAspect.java
+++ b/src/main/java/com/nhnacademy/gateway/common/aspect/RoleCheckAspect.java
@@ -1,0 +1,30 @@
+package com.nhnacademy.gateway.common.aspect;
+
+import com.nhnacademy.gateway.common.annotation.CheckRole;
+import com.nhnacademy.gateway.common.exception.http.ForbiddenException;
+import com.nhnacademy.gateway.common.holder.RoleContextHolder;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public final class RoleCheckAspect {
+
+    @Before("@within(checkRole)")
+    public void checkRoleOnClass(CheckRole checkRole) {
+        verifyRole(checkRole.value().name());
+    }
+
+    @Before("@annotation(checkRole)")
+    public void checkRoleOnMethod(CheckRole checkRole) {
+        verifyRole(checkRole.value().name());
+    }
+
+    private void verifyRole(String required) {
+        String actual = RoleContextHolder.getRole();
+        if (!required.equals(actual)) {
+            throw new ForbiddenException("권한 없음");
+        }
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/common/config/WebConfig.java
+++ b/src/main/java/com/nhnacademy/gateway/common/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.nhnacademy.gateway.common.config;
+
+import com.nhnacademy.gateway.common.interceptor.ContextInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final ContextInterceptor interceptor;
+
+    public WebConfig(ContextInterceptor interceptor) {
+        this.interceptor = interceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(interceptor)
+                .addPathPatterns("/admin/*");
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/common/enums/RoleType.java
+++ b/src/main/java/com/nhnacademy/gateway/common/enums/RoleType.java
@@ -1,0 +1,8 @@
+package com.nhnacademy.gateway.common.enums;
+
+public enum RoleType {
+
+    ROLE_MEMBER,
+
+    ROLE_ADMIN
+}

--- a/src/main/java/com/nhnacademy/gateway/common/exception/http/ForbiddenException.java
+++ b/src/main/java/com/nhnacademy/gateway/common/exception/http/ForbiddenException.java
@@ -1,0 +1,21 @@
+package com.nhnacademy.gateway.common.exception.http;
+
+import com.nhnacademy.gateway.common.exception.CommonHttpException;
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends CommonHttpException {
+
+    private static final int HTTP_STATUS_CODE = HttpStatus.FORBIDDEN.value();
+
+    public ForbiddenException() {
+        this(HttpStatus.FORBIDDEN.getReasonPhrase());
+    }
+
+    public ForbiddenException(final String message) {
+        this(message, null);
+    }
+
+    public ForbiddenException(final String message, final Throwable cause) {
+        super(HTTP_STATUS_CODE, message, cause);
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/common/holder/DepartmentContextHolder.java
+++ b/src/main/java/com/nhnacademy/gateway/common/holder/DepartmentContextHolder.java
@@ -1,0 +1,22 @@
+package com.nhnacademy.gateway.common.holder;
+
+public final class DepartmentContextHolder {
+
+    private static final ThreadLocal<String> DEPARTMENT_HOLDER = new ThreadLocal<>();
+
+    private DepartmentContextHolder() {
+        throw new IllegalStateException("Context Holder class");
+    }
+
+    public static String getDepartmentId() {
+        return DEPARTMENT_HOLDER.get();
+    }
+
+    public static void setDepartmentId(String departmentId) {
+        DEPARTMENT_HOLDER.set(departmentId);
+    }
+
+    public static void clear() {
+        DEPARTMENT_HOLDER.remove();
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/common/holder/RoleContextHolder.java
+++ b/src/main/java/com/nhnacademy/gateway/common/holder/RoleContextHolder.java
@@ -1,0 +1,22 @@
+package com.nhnacademy.gateway.common.holder;
+
+public final class RoleContextHolder {
+
+    private static final ThreadLocal<String> ROLE_HOLDER = new ThreadLocal<>();
+
+    private RoleContextHolder() {
+        throw new IllegalStateException("Context Holder class");
+    }
+
+    public static String getRole() {
+        return ROLE_HOLDER.get();
+    }
+
+    public static void setRole(String role) {
+        ROLE_HOLDER.set(role);
+    }
+
+    public static void clear() {
+        ROLE_HOLDER.remove();
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/common/interceptor/ContextInterceptor.java
+++ b/src/main/java/com/nhnacademy/gateway/common/interceptor/ContextInterceptor.java
@@ -1,0 +1,43 @@
+package com.nhnacademy.gateway.common.interceptor;
+
+import com.nhnacademy.gateway.common.holder.RoleContextHolder;
+import com.nhnacademy.gateway.infrastructure.adapter.UserServiceAdapter;
+import com.nhnacademy.gateway.infrastructure.dto.UserResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Component
+public class ContextInterceptor implements HandlerInterceptor {
+
+    private final UserServiceAdapter userServiceAdapter;
+
+    public ContextInterceptor(
+            @Lazy UserServiceAdapter userServiceAdapter
+    ) {
+        this.userServiceAdapter = userServiceAdapter;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String encryptedEmail = request.getHeader("X-USER-ID");
+
+        if (encryptedEmail != null && !encryptedEmail.isBlank()) {
+            UserResponse userResponse =
+                    userServiceAdapter.getUser(encryptedEmail);
+
+            RoleContextHolder.setRole(
+                    userResponse.getUserRole()
+            );
+        }
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        RoleContextHolder.clear();
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayAdminController.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayAdminController.java
@@ -1,0 +1,30 @@
+package com.nhnacademy.gateway.gateway_info.controller;
+
+import com.nhnacademy.gateway.common.annotation.CheckRole;
+import com.nhnacademy.gateway.common.enums.RoleType;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayAdminSummaryResponse;
+import com.nhnacademy.gateway.gateway_info.service.GatewayService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@CheckRole(RoleType.ROLE_ADMIN)
+@RestController
+@RequestMapping("/admin/gateways")
+public class GatewayAdminController {
+
+    private final GatewayService gatewayService;
+
+    public GatewayAdminController(GatewayService gatewayService) {
+        this.gatewayService = gatewayService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<GatewayAdminSummaryResponse>> getGatewayAdminSummaries() {
+        return ResponseEntity
+                .ok(gatewayService.getGatewayAdminSummaries());
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.gateway.gateway_info.controller;
 
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
-import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
+import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
 import com.nhnacademy.gateway.gateway_info.service.GatewayService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,11 +27,11 @@ public class GatewayController {
     }
 
     @GetMapping
-    public ResponseEntity<List<GatewayWebResponse>> getWebGatewaysByDepartmentId(
+    public ResponseEntity<List<GatewaySummaryResponse>> getGatewaySummariesByDepartmentId(
             @RequestBody String departmentId
     ) {
         return ResponseEntity
-                .ok(gatewayService.getWebGatewaysByDepartmentId(departmentId));
+                .ok(gatewayService.getGatewaySummariesByDepartmentId(departmentId));
     }
 
     @GetMapping("/ids")

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
@@ -1,8 +1,10 @@
 package com.nhnacademy.gateway.gateway_info.controller;
 
+import com.nhnacademy.gateway.gateway_info.dto.GatewayCountUpdateRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
 import com.nhnacademy.gateway.gateway_info.service.GatewayService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/gateways")
 public class GatewayController {
@@ -63,10 +66,14 @@ public class GatewayController {
                 .body(gatewayService.registerGateway(request));
     }
 
-    @PutMapping("/update-count")
+    @PutMapping("/update-sensor-count")
     public ResponseEntity<Void> updateGatewaySensorCount(
-
+            @Validated @RequestBody GatewayCountUpdateRequest request
     ) {
+        gatewayService.updateSensorCountByGatewayId(
+                request.getGatewayId(),
+                request.getSensorCount()
+        );
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
@@ -4,7 +4,6 @@ import com.nhnacademy.gateway.gateway_info.dto.GatewayCountUpdateRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
 import com.nhnacademy.gateway.gateway_info.service.GatewayService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Slf4j
 @RestController
 @RequestMapping("/gateways")
 public class GatewayController {

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.gateway.gateway_info.controller;
 
-import com.nhnacademy.gateway.gateway_info.dto.GatewayInfoResponse;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
 import com.nhnacademy.gateway.gateway_info.service.GatewayService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +9,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,12 +26,12 @@ public class GatewayController {
         this.gatewayService = gatewayService;
     }
 
-    @GetMapping("/department-id/{department-id}")
-    public ResponseEntity<List<GatewayInfoResponse>> getGateways(
-            @PathVariable("department-id") String departmentId
+    @GetMapping
+    public ResponseEntity<List<GatewayWebResponse>> getWebGatewaysByDepartmentId(
+            @RequestBody String departmentId
     ) {
         return ResponseEntity
-                .ok(gatewayService.getGateways(departmentId));
+                .ok(gatewayService.getWebGatewaysByDepartmentId(departmentId));
     }
 
     @GetMapping("/ids")
@@ -62,5 +63,12 @@ public class GatewayController {
                 .body(gatewayService.registerGateway(request));
     }
 
+    @PutMapping("/update-count")
+    public ResponseEntity<Void> updateGatewaySensorCount(
 
+    ) {
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/controller/GatewayController.java
@@ -66,6 +66,7 @@ public class GatewayController {
                 .body(gatewayService.registerGateway(request));
     }
 
+    /// TODO: Sensor-Service만 접근할 수 있도록 구조를 추가
     @PutMapping("/update-sensor-count")
     public ResponseEntity<Void> updateGatewaySensorCount(
             @Validated @RequestBody GatewayCountUpdateRequest request

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/domain/Gateway.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/domain/Gateway.java
@@ -108,4 +108,8 @@ public class Gateway {
     public void preUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void updateSensorCount(int sensorCount) {
+        this.sensorCount = sensorCount;
+    }
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/domain/Gateway.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/domain/Gateway.java
@@ -49,6 +49,9 @@ public class Gateway {
     @Column(name = "description", columnDefinition = "text")
     private String description;
 
+    @Column(name = "sensor_count", nullable = false)
+    private Integer sensorCount;
+
     @Column(name = "threshold_status", columnDefinition = "tinyint")
     private Boolean thresholdStatus;
 
@@ -64,7 +67,7 @@ public class Gateway {
     private Gateway(
             String address, Integer port, IoTProtocol protocol,
             String gatewayName, String clientId, String departmentId,
-            String description, Boolean thresholdStatus
+            String description, Integer sensorCount, Boolean thresholdStatus
     ) {
         this.address = address;
         this.port = port;
@@ -73,13 +76,14 @@ public class Gateway {
         this.clientId = clientId;
         this.departmentId = departmentId;
         this.description = description;
+        this.sensorCount = sensorCount;
         this.thresholdStatus = thresholdStatus;
     }
 
     public static Gateway ofNewGateway(
             String address, Integer port, IoTProtocol protocol,
             String gatewayName, String clientId, String departmentId,
-            String description, Boolean thresholdStatus
+            String description, Integer sensorCount, Boolean thresholdStatus
     ) {
         return new Gateway(
                 address,
@@ -89,6 +93,7 @@ public class Gateway {
                 clientId,
                 departmentId,
                 description,
+                sensorCount,
                 thresholdStatus
         );
     }
@@ -96,6 +101,7 @@ public class Gateway {
     @PrePersist
     public void prePersist() {
         this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
     }
 
     @PreUpdate

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/dto/GatewayAdminSummaryResponse.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/dto/GatewayAdminSummaryResponse.java
@@ -1,0 +1,47 @@
+package com.nhnacademy.gateway.gateway_info.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nhnacademy.gateway.common.enums.IoTProtocol;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public final class GatewayAdminSummaryResponse {
+
+    private final long gatewayId;
+
+    private final String gatewayName;
+
+    @JsonProperty("iot_protocol")
+    private final IoTProtocol ioTProtocol;
+
+    private final String departmentId;
+
+    private final int sensorCount;
+
+    private final boolean thresholdStatus;
+
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy.MM.dd"
+    )
+    private final LocalDateTime updatedAt;
+
+    @QueryProjection
+    public GatewayAdminSummaryResponse(
+            long gatewayId, String gatewayName, IoTProtocol ioTProtocol,
+            String departmentId, int sensorCount, boolean thresholdStatus,
+            LocalDateTime updatedAt
+    ) {
+        this.gatewayId = gatewayId;
+        this.gatewayName = gatewayName;
+        this.ioTProtocol = ioTProtocol;
+        this.departmentId = departmentId;
+        this.sensorCount = sensorCount;
+        this.thresholdStatus = thresholdStatus;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/dto/GatewayCountUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/dto/GatewayCountUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.nhnacademy.gateway.gateway_info.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public final class GatewayCountUpdateRequest {
+
+    @NotNull
+    private final Long gatewayId;
+
+    @NotNull
+    @PositiveOrZero
+    private final Integer sensorCount;
+
+    @JsonCreator
+    public GatewayCountUpdateRequest(
+            @JsonProperty("gateway_id") Long gatewayId,
+            @JsonProperty("sensor_count") Integer sensorCount
+    ) {
+        this.gatewayId = gatewayId;
+        this.sensorCount = sensorCount;
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/dto/GatewaySummaryResponse.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/dto/GatewaySummaryResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public final class GatewayWebResponse {
+public final class GatewaySummaryResponse {
 
     private final long gatewayId;
 
@@ -29,7 +29,7 @@ public final class GatewayWebResponse {
     private final LocalDateTime updatedAt;
 
     @QueryProjection
-    public GatewayWebResponse(
+    public GatewaySummaryResponse(
             long gatewayId, String gatewayName, IoTProtocol ioTProtocol,
             int sensorCount, boolean thresholdStatus, LocalDateTime updatedAt
     ) {

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/dto/GatewayWebResponse.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/dto/GatewayWebResponse.java
@@ -1,0 +1,43 @@
+package com.nhnacademy.gateway.gateway_info.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nhnacademy.gateway.common.enums.IoTProtocol;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public final class GatewayWebResponse {
+
+    private final long gatewayId;
+
+    private final String gatewayName;
+
+    @JsonProperty("iot_protocol")
+    private final IoTProtocol ioTProtocol;
+
+    private final int sensorCount;
+
+    private final boolean thresholdStatus;
+
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy.MM.dd"
+    )
+    private final LocalDateTime updatedAt;
+
+    @QueryProjection
+    public GatewayWebResponse(
+            long gatewayId, String gatewayName, IoTProtocol ioTProtocol,
+            int sensorCount, boolean thresholdStatus, LocalDateTime updatedAt
+    ) {
+        this.gatewayId = gatewayId;
+        this.gatewayName = gatewayName;
+        this.ioTProtocol = ioTProtocol;
+        this.sensorCount = sensorCount;
+        this.thresholdStatus = thresholdStatus;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/repository/CustomGatewayRepository.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/repository/CustomGatewayRepository.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.gateway.gateway_info.repository;
 
 import com.nhnacademy.gateway.broker.mqtt.dto.MqttBroker;
-import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
+import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
 
 import java.util.List;
 
@@ -21,5 +21,5 @@ public interface CustomGatewayRepository {
      */
     List<MqttBroker> getMqttBrokers();
 
-    List<GatewayWebResponse> findWebGatewaysByDepartmentId(String departmentId);
+    List<GatewaySummaryResponse> findGatewaySummariesByDepartmentId(String departmentId);
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/repository/CustomGatewayRepository.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/repository/CustomGatewayRepository.java
@@ -1,7 +1,7 @@
 package com.nhnacademy.gateway.gateway_info.repository;
 
 import com.nhnacademy.gateway.broker.mqtt.dto.MqttBroker;
-import com.nhnacademy.gateway.gateway_info.dto.GatewayInfoResponse;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
 
 import java.util.List;
 
@@ -16,7 +16,10 @@ public interface CustomGatewayRepository {
 
     List<Long> getGatewayIds();
 
+    /**
+     * Gateway-Service 가 내부적으로 사용하는 기능
+     */
     List<MqttBroker> getMqttBrokers();
 
-    List<GatewayInfoResponse> getGateways(String departmentId);
+    List<GatewayWebResponse> findWebGatewaysByDepartmentId(String departmentId);
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/repository/CustomGatewayRepository.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/repository/CustomGatewayRepository.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.gateway.gateway_info.repository;
 
 import com.nhnacademy.gateway.broker.mqtt.dto.MqttBroker;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayAdminSummaryResponse;
 import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
 
 import java.util.List;
@@ -22,4 +23,6 @@ public interface CustomGatewayRepository {
     List<MqttBroker> getMqttBrokers();
 
     List<GatewaySummaryResponse> findGatewaySummariesByDepartmentId(String departmentId);
+
+    List<GatewayAdminSummaryResponse> findGatewayAdminSummaries();
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/repository/impl/CustomGatewayRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/repository/impl/CustomGatewayRepositoryImpl.java
@@ -5,8 +5,8 @@ import com.nhnacademy.gateway.broker.mqtt.dto.QMqttInboundBroker;
 import com.nhnacademy.gateway.common.enums.IoTProtocol;
 import com.nhnacademy.gateway.gateway_info.domain.Gateway;
 import com.nhnacademy.gateway.gateway_info.domain.QGateway;
-import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
-import com.nhnacademy.gateway.gateway_info.dto.QGatewayWebResponse;
+import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
+import com.nhnacademy.gateway.gateway_info.dto.QGatewaySummaryResponse;
 import com.nhnacademy.gateway.gateway_info.repository.CustomGatewayRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
@@ -63,10 +63,10 @@ public class CustomGatewayRepositoryImpl extends QuerydslRepositorySupport imple
     }
 
     @Override
-    public List<GatewayWebResponse> findWebGatewaysByDepartmentId(String departmentId) {
+    public List<GatewaySummaryResponse> findGatewaySummariesByDepartmentId(String departmentId) {
         return queryFactory
                 .select(
-                        new QGatewayWebResponse(
+                        new QGatewaySummaryResponse(
                                 qGateway.gatewayId,
                                 qGateway.gatewayName,
                                 qGateway.protocol,

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/repository/impl/CustomGatewayRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/repository/impl/CustomGatewayRepositoryImpl.java
@@ -5,7 +5,9 @@ import com.nhnacademy.gateway.broker.mqtt.dto.QMqttInboundBroker;
 import com.nhnacademy.gateway.common.enums.IoTProtocol;
 import com.nhnacademy.gateway.gateway_info.domain.Gateway;
 import com.nhnacademy.gateway.gateway_info.domain.QGateway;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayAdminSummaryResponse;
 import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
+import com.nhnacademy.gateway.gateway_info.dto.QGatewayAdminSummaryResponse;
 import com.nhnacademy.gateway.gateway_info.dto.QGatewaySummaryResponse;
 import com.nhnacademy.gateway.gateway_info.repository.CustomGatewayRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -77,6 +79,26 @@ public class CustomGatewayRepositoryImpl extends QuerydslRepositorySupport imple
                 )
                 .from(qGateway)
                 .where(qGateway.departmentId.eq(departmentId))
+                .orderBy(qGateway.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<GatewayAdminSummaryResponse> findGatewayAdminSummaries() {
+        return queryFactory
+                .select(
+                        new QGatewayAdminSummaryResponse(
+                                qGateway.gatewayId,
+                                qGateway.gatewayName,
+                                qGateway.protocol,
+                                qGateway.departmentId,
+                                qGateway.sensorCount,
+                                qGateway.thresholdStatus,
+                                qGateway.updatedAt
+                        )
+                )
+                .from(qGateway)
+                .orderBy(qGateway.createdAt.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/repository/impl/CustomGatewayRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/repository/impl/CustomGatewayRepositoryImpl.java
@@ -5,8 +5,8 @@ import com.nhnacademy.gateway.broker.mqtt.dto.QMqttInboundBroker;
 import com.nhnacademy.gateway.common.enums.IoTProtocol;
 import com.nhnacademy.gateway.gateway_info.domain.Gateway;
 import com.nhnacademy.gateway.gateway_info.domain.QGateway;
-import com.nhnacademy.gateway.gateway_info.dto.GatewayInfoResponse;
-import com.nhnacademy.gateway.gateway_info.dto.QGatewayInfoResponse;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
+import com.nhnacademy.gateway.gateway_info.dto.QGatewayWebResponse;
 import com.nhnacademy.gateway.gateway_info.repository.CustomGatewayRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
@@ -62,21 +62,17 @@ public class CustomGatewayRepositoryImpl extends QuerydslRepositorySupport imple
         );
     }
 
-    public List<GatewayInfoResponse> getGateways(String departmentId) {
+    @Override
+    public List<GatewayWebResponse> findWebGatewaysByDepartmentId(String departmentId) {
         return queryFactory
                 .select(
-                        new QGatewayInfoResponse(
+                        new QGatewayWebResponse(
                                 qGateway.gatewayId,
-                                qGateway.address,
-                                qGateway.port,
-                                qGateway.protocol,
                                 qGateway.gatewayName,
-                                qGateway.clientId,
-                                qGateway.departmentId,
-                                qGateway.description,
-                                qGateway.createdAt,
-                                qGateway.updatedAt,
-                                qGateway.thresholdStatus
+                                qGateway.protocol,
+                                qGateway.sensorCount,
+                                qGateway.thresholdStatus,
+                                qGateway.updatedAt
                         )
                 )
                 .from(qGateway)

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/service/GatewayService.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/service/GatewayService.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.gateway.gateway_info.service;
 
 import com.nhnacademy.gateway.gateway_info.domain.Gateway;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayAdminSummaryResponse;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
@@ -24,4 +25,6 @@ public interface GatewayService {
     List<Long> getGatewayIds();
 
     List<GatewaySummaryResponse> getGatewaySummariesByDepartmentId(String departmentId);
+
+    List<GatewayAdminSummaryResponse> getGatewayAdminSummaries();
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/service/GatewayService.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/service/GatewayService.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.gateway.gateway_info.service;
 
+import com.nhnacademy.gateway.gateway_info.domain.Gateway;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
@@ -11,6 +12,10 @@ public interface GatewayService {
     String[] getSupportedProtocols();
 
     long registerGateway(GatewayRegisterRequest request);
+
+    Gateway getGatewayByGatewayId(long gatewayId);
+
+    void updateSensorCountByGatewayId(long gatewayId, int sensorCount);
 
     boolean isExistsGateway(GatewayRequest request);
 

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/service/GatewayService.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/service/GatewayService.java
@@ -2,7 +2,7 @@ package com.nhnacademy.gateway.gateway_info.service;
 
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRequest;
-import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
+import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
 
 import java.util.List;
 
@@ -18,5 +18,5 @@ public interface GatewayService {
 
     List<Long> getGatewayIds();
 
-    List<GatewayWebResponse> getWebGatewaysByDepartmentId(String departmentId);
+    List<GatewaySummaryResponse> getGatewaySummariesByDepartmentId(String departmentId);
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/service/GatewayService.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/service/GatewayService.java
@@ -1,8 +1,8 @@
 package com.nhnacademy.gateway.gateway_info.service;
 
-import com.nhnacademy.gateway.gateway_info.dto.GatewayInfoResponse;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRequest;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
 
 import java.util.List;
 
@@ -18,5 +18,5 @@ public interface GatewayService {
 
     List<Long> getGatewayIds();
 
-    List<GatewayInfoResponse> getGateways(String departmentId);
+    List<GatewayWebResponse> getWebGatewaysByDepartmentId(String departmentId);
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/service/impl/GatewayServiceImpl.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/service/impl/GatewayServiceImpl.java
@@ -6,7 +6,7 @@ import com.nhnacademy.gateway.common.exception.http.extend.GatewayNotFoundExcept
 import com.nhnacademy.gateway.gateway_info.domain.Gateway;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRequest;
-import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
+import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
 import com.nhnacademy.gateway.gateway_info.repository.GatewayRepository;
 import com.nhnacademy.gateway.gateway_info.service.GatewayService;
 import org.springframework.stereotype.Service;
@@ -74,7 +74,7 @@ public class GatewayServiceImpl implements GatewayService {
     }
 
     @Override
-    public List<GatewayWebResponse> getWebGatewaysByDepartmentId(String departmentId) {
-        return gatewayRepository.findWebGatewaysByDepartmentId(departmentId);
+    public List<GatewaySummaryResponse> getGatewaySummariesByDepartmentId(String departmentId) {
+        return gatewayRepository.findGatewaySummariesByDepartmentId(departmentId);
     }
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/service/impl/GatewayServiceImpl.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/service/impl/GatewayServiceImpl.java
@@ -4,6 +4,7 @@ import com.nhnacademy.gateway.common.enums.IoTProtocol;
 import com.nhnacademy.gateway.common.exception.http.extend.GatewayAlreadyExistsException;
 import com.nhnacademy.gateway.common.exception.http.extend.GatewayNotFoundException;
 import com.nhnacademy.gateway.gateway_info.domain.Gateway;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayAdminSummaryResponse;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
@@ -75,6 +76,7 @@ public class GatewayServiceImpl implements GatewayService {
         );
     }
 
+    @Transactional(readOnly = true)
     @Override
     public String getDepartmentIdByGatewayId(long gatewayId) {
         if (!isExistsGatewayId(gatewayId)) {
@@ -83,13 +85,21 @@ public class GatewayServiceImpl implements GatewayService {
         return gatewayRepository.getDepartmentIdByGatewayId(gatewayId);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<Long> getGatewayIds() {
         return gatewayRepository.getGatewayIds();
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<GatewaySummaryResponse> getGatewaySummariesByDepartmentId(String departmentId) {
         return gatewayRepository.findGatewaySummariesByDepartmentId(departmentId);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<GatewayAdminSummaryResponse> getGatewayAdminSummaries() {
+        return gatewayRepository.findGatewayAdminSummaries();
     }
 }

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/service/impl/GatewayServiceImpl.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/service/impl/GatewayServiceImpl.java
@@ -10,11 +10,13 @@ import com.nhnacademy.gateway.gateway_info.dto.GatewaySummaryResponse;
 import com.nhnacademy.gateway.gateway_info.repository.GatewayRepository;
 import com.nhnacademy.gateway.gateway_info.service.GatewayService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
+@Transactional
 public class GatewayServiceImpl implements GatewayService {
 
     private final GatewayRepository gatewayRepository;
@@ -46,6 +48,19 @@ public class GatewayServiceImpl implements GatewayService {
         );
         return gatewayRepository.save(gateway)
                 .getGatewayId();
+    }
+
+    @Override
+    public Gateway getGatewayByGatewayId(long gatewayId) {
+        return gatewayRepository.findById(gatewayId)
+                .orElseThrow(GatewayNotFoundException::new);
+    }
+
+    @Override
+    public void updateSensorCountByGatewayId(long gatewayId, int sensorCount) {
+        Gateway gateway = getGatewayByGatewayId(gatewayId);
+        gateway.updateSensorCount(sensorCount);
+        gatewayRepository.flush();
     }
 
     public boolean isExistsGatewayId(long gatewayId) {

--- a/src/main/java/com/nhnacademy/gateway/gateway_info/service/impl/GatewayServiceImpl.java
+++ b/src/main/java/com/nhnacademy/gateway/gateway_info/service/impl/GatewayServiceImpl.java
@@ -4,9 +4,9 @@ import com.nhnacademy.gateway.common.enums.IoTProtocol;
 import com.nhnacademy.gateway.common.exception.http.extend.GatewayAlreadyExistsException;
 import com.nhnacademy.gateway.common.exception.http.extend.GatewayNotFoundException;
 import com.nhnacademy.gateway.gateway_info.domain.Gateway;
-import com.nhnacademy.gateway.gateway_info.dto.GatewayInfoResponse;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRegisterRequest;
 import com.nhnacademy.gateway.gateway_info.dto.GatewayRequest;
+import com.nhnacademy.gateway.gateway_info.dto.GatewayWebResponse;
 import com.nhnacademy.gateway.gateway_info.repository.GatewayRepository;
 import com.nhnacademy.gateway.gateway_info.service.GatewayService;
 import org.springframework.stereotype.Service;
@@ -41,6 +41,7 @@ public class GatewayServiceImpl implements GatewayService {
                 UUID.randomUUID().toString(),
                 request.getDepartmentId(),
                 request.getDescription(),
+                0,
                 false
         );
         return gatewayRepository.save(gateway)
@@ -73,7 +74,7 @@ public class GatewayServiceImpl implements GatewayService {
     }
 
     @Override
-    public List<GatewayInfoResponse> getGateways(String departmentId) {
-        return gatewayRepository.getGateways(departmentId);
+    public List<GatewayWebResponse> getWebGatewaysByDepartmentId(String departmentId) {
+        return gatewayRepository.findWebGatewaysByDepartmentId(departmentId);
     }
 }

--- a/src/main/java/com/nhnacademy/gateway/infrastructure/adapter/UserServiceAdapter.java
+++ b/src/main/java/com/nhnacademy/gateway/infrastructure/adapter/UserServiceAdapter.java
@@ -1,0 +1,15 @@
+package com.nhnacademy.gateway.infrastructure.adapter;
+
+import com.nhnacademy.gateway.infrastructure.dto.UserResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "user-service")
+public interface UserServiceAdapter {
+
+    @GetMapping("/users/me")
+    UserResponse getUser(
+            @RequestHeader("X-USER-ID") String encryptedEmail
+    );
+}

--- a/src/main/java/com/nhnacademy/gateway/infrastructure/dto/UserResponse.java
+++ b/src/main/java/com/nhnacademy/gateway/infrastructure/dto/UserResponse.java
@@ -1,0 +1,48 @@
+package com.nhnacademy.gateway.infrastructure.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public final class UserResponse {
+
+    String userRole;
+
+    Long userNo;
+
+    String userName;
+
+    String userEmail;
+
+    String userPhone;
+
+    DepartmentResponse department;
+
+    EventLevelResponse eventLevelResponse;
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class DepartmentResponse {
+
+        private String departmentId;
+
+        private String departmentName;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class EventLevelResponse {
+
+        private String eventLevelName;
+
+        private String eventLevelDetails;
+
+        private Integer priority;
+    }
+}


### PR DESCRIPTION
## 목차

1. `gateways` 내에 `department_id`와 일치하는 모든 행의 데이터를 조회하는 기능을 추가
2. **HTTP** `/admin/*` 구조로 요청 시, 커스텀 헤더 `X-USER-ID` 값을 통해 사용자의 권한을 확인하는 기능을 추가
3. 관리자 권한을 지닌 이용자가 **HTTP** `/admin/gateways`를 요청 시, `gateways` 내의 모든 행의 데이터를 조회하는 기능을 추가

---

### 1. `gateways` 내에 `department_id`와 일치하는 모든 행의 데이터를 조회하는 기능 추가

```http
GET http://team1-gateway-service:10241/gateways

1
```

- 위의 형식으로 **HTTP GET** 요청 시, 아래와 같은 구조로 데이터로 반환합니다.

```json
[
  {
    "gateway_id": 1,
    "gateway_name": "NHN Academy 경남",
    "sensor_count": 41,
    "threshold_status": false,
    "updated_at": "2025.06.05",
    "iot_protocol": "MQTT"
  }
]
```

---

### 2. **HTTP** `/admin/*` 구조로 요청 시, 커스텀 헤더 `X-USER-ID` 값을 통해서 하나의 요청에 대응되는 사용자의 권한을 확인하는 기능 추가

- **Spring Interceptor**를 활용하여 `/admin/*` 경로로 들어오는 요청에 대해 커스텀 헤더 `X-USER-ID` 값을
기반으로 `User-Service`에 인증 정보를 요청하고, 해당 사용자의 권한을 검증하는 기능을 추가

- 이후 `User-Service`로부터 전달받은 사용자 권한 정보를 `ThreadLocal` 기반으로
구현된 `ContextHolder`에 저장하여, 이후 로직에서 전역적으로 활용할 수 있도록 합니다.

---

### 3. 관리자 권한을 지닌 이용자가 **HTTP** `/admin/gateways`를 요청 시, `gateways` 내의 모든 행의 데이터를 조회하는 기능 추가

```http
GET http://team1-gateway-service:10241/admin/gateways
```

- 위의 형식으로 **HTTP GET** 요청 시, 아래와 같은 구조로 데이터로 반환합니다.

```json
[
  {
    "gateway_id": 1,
    "gateway_name": "NHN Academy 경남",
    "sensor_count": 41,
    "threshold_status": false,
    "updated_at": "2025.06.05",
    "iot_protocol": "MQTT"
  },
  {
    "gateway_id": 2,
    "gateway_name": "NHN Academy 경남",
    "sensor_count": 12,
    "threshold_status": false,
    "updated_at": "2025.06.05",
    "iot_protocol": "MODBUS_TCP"
  }
]
```